### PR TITLE
Added consistent title styling to About page.

### DIFF
--- a/client/stylesheets/sass/pages/about.scss
+++ b/client/stylesheets/sass/pages/about.scss
@@ -1,6 +1,5 @@
-.about-container {
-  max-width: 800px;
-  margin: 0 auto;
+.about-page {
+  // max-width: 800px;
   position: relative;
 }
 
@@ -25,6 +24,7 @@
   }
   .member-description {
     p {
+      width: 150px;
       margin: 0;
     }
   }

--- a/client/views/about.html
+++ b/client/views/about.html
@@ -1,5 +1,5 @@
 <template name="about">
-  <div class="about-container container">
+  <div class="about-page page-container container">
     <div class="title">Council</div>
 
     <div class="council-images">


### PR DESCRIPTION
In order to keep the styling consistent across pages, I didn't change the page container margins for the About page. This means that the page doesn't exactly match the designs, unfortunately (the block for staff images is wider than in the designs). To make the page look more similar to the designs, add `max-width: 1000px` to the `.about-page` styles.
